### PR TITLE
Fix leaves in ore dict not being detected

### DIFF
--- a/src/main/java/panda/birdsnests/HarvestLeafEventHandler.java
+++ b/src/main/java/panda/birdsnests/HarvestLeafEventHandler.java
@@ -17,22 +17,36 @@ public class HarvestLeafEventHandler {
 
 	@SubscribeEvent
 	public void onDrops(BlockEvent.BreakEvent event) {
-
 		Block theblock = event.getState().getBlock();
-		if (  theblock == Blocks.LEAVES || theblock == Blocks.LEAVES2||OreDictionary.getOres("treeLeaves").contains(new ItemStack(theblock)))
+		if (theblock instanceof BlockLeaves || isLeafInOreDict(theblock))
 		{
-			BlockLeaves leaves = (BlockLeaves)theblock;
-
-			if(((Boolean)event.getState().getValue(PropertyBool.create("decayable"))).booleanValue()){
+			boolean decayable = false;
+			// Not all ore dict entries will have the decayable property
+			try {
+				decayable = event.getState().getValue(BlockLeaves.DECAYABLE);
+			} catch (IllegalArgumentException ignore) {}
+			if(decayable){
 				if (event.getWorld().rand.nextInt(BirdsNests.nestRarity) == 0)
 				{	 
 					double d0 = event.getWorld().rand.nextFloat() * f + (1.0F - f) * 0.5D;
 					double d1 = event.getWorld().rand.nextFloat() * f + (1.0F - f) * 0.5D;
 					double d2 = event.getWorld().rand.nextFloat() * f + (1.0F - f) * 0.5D;
-					EntityItem entityitem = new EntityItem(event.getWorld(),event.getPos().getX()+d0,event.getPos().getY()+d1,event.getPos().getZ()+d2, new ItemStack(BirdsNests.nest,(BirdsNests.use32) ? 1 : 0, 1));
+					EntityItem entityitem = new EntityItem(event.getWorld(),event.getPos().getX()+d0,event.getPos().getY()+d1,event.getPos().getZ()+d2, new ItemStack(BirdsNests.nest, 1, (BirdsNests.use32) ? 1 : 0));
 					event.getWorld().spawnEntityInWorld(entityitem);
 				}
 			}
 		}
+	}
+
+	/**
+	 * Checks if the block is registered as "treeLeaves" in the ore dictionary
+	 * @param block block to check
+	 * @return matching item is found in ore dictionary
+	 */
+	private boolean isLeafInOreDict(Block block) {
+		for (ItemStack oreDictEntry : OreDictionary.getOres("treeLeaves"))
+			if (ItemStack.areItemsEqual(oreDictEntry, new ItemStack(block)))
+				return true;
+		return false;
 	}
 }


### PR DESCRIPTION
When checking for entries in the ore dictionary, `contains` is called on a NonNullList. This calls `equals`  on an itemstack and a new instance of an itemstack which will never return true.

`new ItemStack(Blocks.LEAVES).equals(new ItemStack(Blocks.LEAVES))`  - false

`ItemStack.areItemsEqual(new ItemStack(Blocks.LEAVES), new ItemStack(Blocks.LEAVES))` - true

